### PR TITLE
Fix contradicción en estaEntre y estaFueraDeRango

### DIFF
--- a/00006_Booleanos/test..js
+++ b/00006_Booleanos/test..js
@@ -17,8 +17,8 @@ describe("", function() {
 })
 
 describe("estaFueraDeRango", function() {
-  it("estaFueraDeRango(10, 1, 10) es false", function() {
-    assert(!estaFueraDeRango(10, 1, 10));
+  it("estaFueraDeRango(10, 1, 10) es true", function() {
+    assert(estaFueraDeRango(10, 1, 10));
   });
   it("estaFueraDeRango(12, 1, 10) es true", function() {
     assert(estaFueraDeRango(12, 1, 10));


### PR DESCRIPTION
El test que de las líneas [2-4] dice que el rango es no inclusivo, es decir: estaEntre(10, 1, 10) es false.
El test que va de las líneas [20-22] dice que el rango es inclusivo, es decir: estaFueraDeRango(10, 1, 10) es false.
Supuse que el primero de dichos tests es el que está bien.